### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/Android_Heart_First/MyMusic/app/src/main/AndroidManifest.xml
+++ b/Android_Heart_First/MyMusic/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.example.mymusic">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
For allow: Backup always set to false if it is true, this is considered a security issue because people could backup your app via ADB and then get private data of your app into their PC.